### PR TITLE
Update setup.py and reqs

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ mpld3: A D3 Viewer for Matplotlib
 - License: BSD 3-clause
 
 This is a minimal interactive viewer for matplotlib graphics built on D3.
-For an example of the code in action, see the [blog post](http://jakevdp.github.io/blog/2013/12/19/a-d3-viewer-for-matplotlib/), or the 
+For an example of the code in action, see the [blog post](http://jakevdp.github.io/blog/2013/12/19/a-d3-viewer-for-matplotlib/), or the
 [IPython notebook examples](http://nbviewer.ipython.org/github/jakevdp/mpld3/tree/master/examples/)
 available in the ``examples`` directory of this repository.
 
@@ -14,6 +14,10 @@ matplotlib's features.  It should be considered a proof-of-concept, for now.
 
 Installation
 ------------
+To install the dependencies:
+
+    [~]$pip install -r requirements.txt
+
 To install the library system-wide
 
     [~]$ python setup.py install

--- a/mpld3/__init__.py
+++ b/mpld3/__init__.py
@@ -1,5 +1,3 @@
-__version__ = '0.0.1'
-
 __all__ = ["fig_to_d3"]
 
 from ._objects import D3Figure

--- a/mpld3/_objects.py
+++ b/mpld3/_objects.py
@@ -2,8 +2,6 @@ import abc
 import uuid
 import warnings
 
-import numpy as np
-
 from ._utils import get_text_coordinates, color_to_hex, get_dasharray
 
 
@@ -46,7 +44,7 @@ class D3Base(object):
 
     def __str__(self):
         return self.html()
-        
+
 
 class D3Figure(D3Base):
     """Class for representing a matplotlib Figure in D3js"""
@@ -200,12 +198,12 @@ class D3Axes(D3Base):
                              .attr("y", 0)
                              .attr("width", width_{axid})
                              .attr("height", height_{axid});
- 
+
     // axes_{axid} is the axes on which to draw plot components: they'll
     // be clipped when zooming or scrolling moves them out of the plot.
     var axes_{axid} = baseaxes_{axid}.append('g')
             .attr("clip-path", "url(#clip{axid})");
-    
+
     {elements}
 
     function zoomed{axid}() {{
@@ -244,7 +242,7 @@ class D3Axes(D3Base):
             fontsize_x = ticks[0].properties()['size']
         return '\n'.join([self.STYLE.format(axid=self.axid,
                                             figid=self.figid,
-                                            fontsize=fontsize_x)] + 
+                                            fontsize=fontsize_x)] +
                          [g.style() for g in self.grids] +
                          [l.style() for l in self.lines] +
                          [t.style() for t in self.texts])
@@ -274,7 +272,7 @@ class D3Grid(D3Base):
       stroke-dasharray: {dasharray};
       stroke-opacity: {alpha};
     }}
-    
+
     div#figure{figid}
     .grid path {{
       stroke-width: 0;
@@ -452,7 +450,7 @@ class D3Line2D(D3Base):
                                  markercolor=mc,
                                  dasharray=dasharray,
                                  alpha=alpha)
-        
+
     def html(self):
         data = self.line.get_xydata().tolist()
         alpha = self.line.get_alpha()
@@ -496,11 +494,11 @@ class D3Text(D3Base):
     """
     def __init__(self, parent, ax, text):
         self._initialize(parent=parent, ax=ax, text=text)
-    
+
     def html(self):
         if not self.text.get_text():
             return ''
-        
+
         if self.text.get_transform() is self.ax.transData:
             # TODO: anchor this text to the axes, rather than to the figure.
             pass
@@ -513,7 +511,7 @@ class D3Text(D3Base):
         # hack for y-label alignment
         if self.text is self.ax.yaxis.label:
             x += fontsize
-            
+
         return self.TEXT_TEMPLATE.format(text=self.text.get_text(),
                                          x=x, y=y,
                                          fontsize=fontsize,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,11 @@
+numpy==1.8.0
+matplotlib==1.3.1
+nose==1.3.0
+pyparsing==2.0.1
+python-dateutil==2.2
+six==1.4.1
+tornado==3.1.1
+wsgiref==0.1.2
+pyzmq==14.0.1
+Jinja2==2.7.1
+ipython==1.1.0

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,7 @@
-from distutils.core import setup
+try:
+    from setuptools import setup
+except ImportError:
+    from distutils.core import setup
 
 DESCRIPTION = "D3 Viewer for Matplotlib"
 LONG_DESCRIPTION = DESCRIPTION
@@ -9,10 +12,7 @@ MAINTAINER = "Jake VanderPlas"
 MAINTAINER_EMAIL = "jakevdp@cs.washington.edu"
 DOWNLOAD_URL = 'http://github.com/jakevdp/mpld3'
 LICENSE = 'BSD 3-clause'
-
-# partial import to get version
-import mpld3
-VERSION = mpld3.__version__
+VERSION = '0.0.1'
 
 setup(name=NAME,
       version=VERSION,
@@ -25,5 +25,5 @@ setup(name=NAME,
       url=DOWNLOAD_URL,
       download_url=DOWNLOAD_URL,
       license=LICENSE,
-      packages=['mpld3']
+      packages=['mpld3'],
      )


### PR DESCRIPTION
It looks like my text editor got a little zealous with the whitespace cleansing. 

Changes: 
- Move version into setup.py and mpld3 out of it. I'm happy to change this back, but I usually try to avoid importing the package itself in the setup file. 
- Try to use setuptools tools with a fallback to distutils. This lets you use `python setup.py develop` to make for happy dev times. 
- Add a requirements file and pip install instructions in the Readme. These should be the min reqs required to get running, and in an order that allows for a clean `pip install -r requirements` for new users. 
