### PR TITLE
Allow to popup new window with d3 figure

### DIFF
--- a/mpld3/_html_utils.py
+++ b/mpld3/_html_utils.py
@@ -1,0 +1,62 @@
+BUTTON_TEMPLATE = """
+<button class="mpld3_button" id='button{figid}' onclick="open_figured{figid}()">Open in a new window</button>
+"""
+
+BUTTON_SCRIPT = """
+    <script  type="text/javascript">
+      function open_figured{figid}()
+      {{
+        window.open("file://{fig_url_new_window}",
+                    "_blank",
+                    "toolbar=no, scrollbars=yes, resizable=yes, top=100, left=100, width={width}, height={height}, titlebar=no, menubar=no, location=yes");
+      }}
+    </script>
+"""
+
+BUTTON_STYLE = """
+    <style>
+
+    .mpld3_button {
+      overflow: visible;
+      display: inline-block;
+      padding: 0.5em 1em;
+      border: 1px solid #d4d4d4;
+      margin: 0;
+      text-decoration: none;
+      text-shadow: 1px 1px 0 #fff;
+      font: 100%/normal sans-serif;
+      color: #333;
+      white-space: nowrap;
+      cursor: pointer;
+      outline: none;
+      background-color: #ececec;
+      background-image: -webkit-gradient(linear, 0 0, 0 100%, from(#f4f4f4), to(#ececec));
+      background-image: -moz-linear-gradient(#f4f4f4, #ececec);
+      background-image: -o-linear-gradient(#f4f4f4, #ececec);
+      background-image: linear-gradient(#f4f4f4, #ececec);
+      -webkit-background-clip: padding;
+      -moz-background-clip: padding;
+      -o-background-clip: padding-box;
+      background-clip: padding-box;
+      -webkit-border-radius: 0.2em;
+      -moz-border-radius: 0.2em;
+      border-radius: 0.2em;
+      zoom: 1;
+    }
+
+    .mpld3_button:hover,
+    .mpld3_button:focus,
+    .mpld3_button:active {
+      border-color: #3072b3;
+      border-bottom-color: #2a65a0;
+      text-decoration: none;
+      text-shadow: -1px -1px 0 rgba(0,0,0,0.3);
+      color: #fff;
+      background-color: #3072b3;
+      background-image: -webkit-gradient(linear, 0 0, 0 100%, from(#599bdc), to(#3072b3));
+      background-image: -moz-linear-gradient(#599bdc, #3072b3);
+      background-image: -o-linear-gradient(#599bdc, #3072b3);
+      background-image: linear-gradient(#599bdc, #3072b3);
+      }
+    </style>
+"""


### PR DESCRIPTION
Not currently working so don't merge it

What the PR do:
- add "Open in a new window" button below current figure
- save temp file with figure html code (without button) when self.html is called
- when the button is clicked a new window open on temp file

It actually does not work. Which mean when the window is open, url is "about:blank". But when I manually open the temp file in the browser, it works. I don't know why...

Anyway saving html code in a temp file is not good in my opinion for two things:
- temp file is created each time self.html and never closed, it should be only called when user click on button and close when user close window
- figure html code of the new window should be served by ipython kernel with something like that : http://127.0.0.1:8888/notebooks/test.ipynb/show_figure6f27767e1b0b4f0abb883870a2edc693/ but I don't know wether it is possible to serve simple html file with ipython notebook.

If someone know how to do it I will be glade to add it to the PR.

TODO: dynamically resize figure to window size (maybe add small border too). See http://stackoverflow.com/questions/14265112/d3-js-map-svg-auto-fit-into-parent-container-and-resize-with-window and http://eyeseast.github.io/visible-data/2013/08/28/responsive-charts-with-d3/
