### PR TITLE
Time scale support for x axis

### DIFF
--- a/mpld3/_objects.py
+++ b/mpld3/_objects.py
@@ -153,6 +153,13 @@ class D3Axes(D3Base):
     var x_data_map{axid} = x_{axid};
     """
 
+    LOG_XAXIS_TEMPLATE = """
+    var x_{axid} = d3.scale.log()
+                     .domain([{xlim[0]}, {xlim[1]}])
+                     .range([0, width_{axid}]);
+    var x_data_map{axid} = x_{axid};
+    """
+
     DATE_XAXIS_TEMPLATE = """
     var start_date_x{axid} = new Date({d0[0]}, {d0[1]}, {d0[2]}, {d0[3]},
                                       {d0[4]}, {d0[5]}, {d0[6]});
@@ -174,8 +181,15 @@ class D3Axes(D3Base):
 
     YAXIS_TEMPLATE = """
     var y_{axid} = d3.scale.linear()
-                       .domain([{ylim[0]}, {ylim[1]}])
-                       .range([height_{axid}, 0]);
+                           .domain([{ylim[0]}, {ylim[1]}])
+                           .range([height_{axid}, 0]);
+    var y_data_map{axid} = y_{axid};
+    """
+
+    LOG_YAXIS_TEMPLATE = """
+    var y_{axid} = d3.scale.log()
+                           .domain([{ylim[0]}, {ylim[1]}])
+                           .range([height_{axid}, 0]);
     var y_data_map{axid} = y_{axid};
     """
 
@@ -190,9 +204,9 @@ class D3Axes(D3Base):
                       .range([0, width_{axid}]);
 
     var y_reverse_date_scale_{axid} = d3.time.scale()
-                                        .domain([start_date_y{axid},
-                                                 end_date_y{axid}])
-                                        .range([{ylim[0]}, {ylim[1]}]);
+                                             .domain([start_date_y{axid},
+                                                      end_date_y{axid}])
+                                             .range([{ylim[0]}, {ylim[1]}]);
 
     var y_data_map{axid} = function (y)
                 {{ return y_{axid}(y_reverse_date_scale_{axid}.invert(y));}}
@@ -352,9 +366,14 @@ class D3Axes(D3Base):
                                          xlim=self.ax.get_xlim(),
                                          d0=d0, d1=d1)
         else:
-
-            xaxis_code = self.XAXIS_TEMPLATE.format(axid=self.axid,
-                                                    xlim=self.ax.get_xlim())
+            if self.ax.get_xscale() == 'log':
+                template = self.LOG_XAXIS_TEMPLATE
+            elif self.ax.get_xscale() == 'linear':
+                template = self.XAXIS_TEMPLATE
+            else:
+                assert False, "unknown axis scale"
+            xaxis_code = template.format(axid=self.axid,
+                                         xlim=self.ax.get_xlim())
 
         if isinstance(self.ax.yaxis.converter, matplotlib.dates.DateConverter):
             date0, date1 = matplotlib.dates.num2date(self.ax.get_ylim())
@@ -367,8 +386,14 @@ class D3Axes(D3Base):
                                          ylim=self.ax.get_ylim(),
                                          d0=d0, d1=d1)
         else:
-            yaxis_code = self.YAXIS_TEMPLATE.format(axid=self.axid,
-                                                    ylim=self.ax.get_ylim())
+            if self.ax.get_yscale() == 'log':
+                template = self.LOG_YAXIS_TEMPLATE
+            elif self.ax.get_yscale() == 'linear':
+                template = self.YAXIS_TEMPLATE
+            else:
+                assert False, "unknown axis scale"
+            yaxis_code = template.format(axid=self.axid,
+                                         ylim=self.ax.get_ylim())
 
         return self.AXES_TEMPLATE.format(id=id(self.ax),
                                          axid=self.axid,

--- a/test_plots/test_date.py
+++ b/test_plots/test_date.py
@@ -6,14 +6,14 @@ import datetime
 import time
 
 def main():
-    otimes = map(datetime.datetime.fromtimestamp, [time.time()+i*500
+    otimes = map(datetime.datetime.fromtimestamp, [time.time() + i * 500
                                                    for i in range(10)])
     times = matplotlib.dates.date2num(otimes)
 
     fig, ax = plt.subplots()
     ax.xaxis_date()
     fig.autofmt_xdate()
-    ax.plot_date(times, range(10),"-",linewidth=3)
+    ax.plot(times, range(10), "-", linewidth=3)
     return fig
 
 if __name__ == '__main__':

--- a/test_plots/test_logscale.py
+++ b/test_plots/test_logscale.py
@@ -1,0 +1,19 @@
+"""Plot to test logscale"""
+import matplotlib.pyplot as plt
+import numpy as np
+
+def main():
+    fig, ax = plt.subplots(2, 2)
+    fig.subplots_adjust(hspace=0.4, wspace=0.4)
+    x = np.linspace(1e-3, 1e3)
+    y = x ** 2
+
+    ax[0, 0].plot(x, y)
+    ax[0, 1].semilogx(x, y)
+    ax[1, 0].semilogy(x, y)
+    ax[1, 1].loglog(x, y)
+    return fig
+
+if __name__ == '__main__':
+    main()
+    plt.show()


### PR DESCRIPTION
Hi, Thanks again for providing this, it is coming together nicely.

This adds support for date ranges on the x axis. d3.time.scale() is used to create the scale and it automatically formats the dates as you zoom. I was unsure about a few things: how do you tell if a matplotlib axis is a time scale? I currently check the type of ax.xaxis.converter, which seems to work. 

I had to introduce an extra javascript function to map from the matplotlib floating point date format to a javascript date object and again to the width of the figure. There must be a better way to do this? Maybe transform the actual data array in the javascript part?

For future reference, if you are creating javascript date objects with the Date() constructor: the month is specified as an integer from 0 to 11. This caused me some confusion. 

Here my test case.

``` python
import numpy as np
import pylab as plt
import matplotlib
import datetime
import time
from mpld3.display import display_d3

otimes = map(datetime.datetime.fromtimestamp, [time.time()+i*500
                                              for i in range(10)])
times = matplotlib.dates.date2num(otimes)

plt.gca().xaxis_date()
plt.gcf().autofmt_xdate()

plt.plot_date(times, range(10), "-",linewidth=3)

print plt.gca().get_xlim()

#plt.show()
display_d3(plt.gcf())
```
