### PR TITLE
BUG: Until ordering is handled properly, put images in back.

### DIFF
--- a/mpld3/_objects.py
+++ b/mpld3/_objects.py
@@ -242,6 +242,8 @@ class D3Axes(D3Base):
         # TODO: re-order children according to their zorder.
         self.children = [D3Axis(self, "bottom"), D3Axis(self, "left")]
 
+        self.children += [D3Image(self, ax, image) for image in ax.images]
+
         if self.has_xgrid():
             self.children.append(D3Grid(self, 'x'))
         if self.has_ygrid():
@@ -250,7 +252,6 @@ class D3Axes(D3Base):
         self.children += [D3Line2D(self, line) for line in ax.lines]
         self.children += [D3Patch(self, patch)
                           for i, patch in enumerate(ax.patches)]
-        self.children += [D3Image(self, ax, image) for image in ax.images]
 
         for collection in ax.collections:
             if isinstance(collection, mpl.collections.PolyCollection):


### PR DESCRIPTION
Lines should display in front of images. This was broken amidst refactoring (not sure exactly when).

As a code comment says, ultimately, placement should respect z order. But in the mean time, this fix makes it possible to plot points/lines/whatever over images, the normal usage.
