### PR TITLE
Make tooltips work with plot()

### DIFF
--- a/mpld3/plugins.py
+++ b/mpld3/plugins.py
@@ -75,7 +75,7 @@ class PointLabelTooltip(PluginBase):
     >>> from mpld3 import fig_to_d3
     >>> fig, ax = plt.subplots()
     >>> points = ax.plot(range(10), 'o')
-    >>> fig.plugins = [PointLabelTooltip(points)]
+    >>> fig.plugins = [PointLabelTooltip(points[0])]
     >>> fig_to_d3(fig)
     """
 

--- a/test_plots/test_plot_w_tooltips.py
+++ b/test_plots/test_plot_w_tooltips.py
@@ -6,7 +6,7 @@ from mpld3 import plugins, fig_to_d3
 def main():
     fig, ax = plt.subplots()
     points = ax.plot(range(10), 'o')
-    fig.plugins = [plugins.PointLabelTooltip(points)]
+    fig.plugins = [plugins.PointLabelTooltip(points[0])]
 
     return fig
 

--- a/test_plots/test_scatter.py
+++ b/test_plots/test_scatter.py
@@ -1,7 +1,7 @@
 """Plot to test line styles"""
 import matplotlib.pyplot as plt
 import numpy as np
-from mpld3 import plugins
+from mpld3 import plugins, fig_to_d3
 
 def main():
     fig, ax = plt.subplots(subplot_kw=dict(axisbg='#EEEEEE'))
@@ -23,5 +23,6 @@ def main():
     return fig
 
 if __name__ == '__main__':
-    main()
-    plt.show()
+    fig = main()
+    fig_to_d3(fig)
+


### PR DESCRIPTION
There is probably a more elegant way to handle this, and documentation will sort it all out.  But right now, this makes the docstring example from plugins.py work for me, and adds a test so we'll notice if future changes break it.
