### PR TITLE
BUG-FIX: PointLabelTooltip displays wrong when more than 1 plugin in fig

### DIFF
--- a/mpld3/plugins.py
+++ b/mpld3/plugins.py
@@ -89,7 +89,7 @@ class PointLabelTooltip(PluginBase):
                   .style("visibility", "hidden");
 
     {% if labels != 'null' %}
-    var labels = {{ labels }};
+    var labels{{ id }}  = {{ labels }};
     {% endif %}
 
     ax{{ axid }}.axes.selectAll(".{{ pointclass }}{{ elid }}")
@@ -97,7 +97,7 @@ class PointLabelTooltip(PluginBase):
                            tooltip{{ id }}
                               .style("visibility", "visible")
                               {% if labels != 'null' %}
-                              .text(labels[i])
+                              .text(labels{{ id }} [i])
                               {% else %}
                               .text("(" + d[0] + ", " + d[1] + ")")
                               {% endif %};})

--- a/test_plots/test_plot_w_tooltips_labels.py
+++ b/test_plots/test_plot_w_tooltips_labels.py
@@ -1,0 +1,21 @@
+"""Plot to test line styles"""
+import matplotlib.pyplot as plt
+import numpy as np
+from mpld3 import plugins, fig_to_d3
+
+def main():
+    fig, ax = plt.subplots()
+    fig.plugins = []
+    colors = plt.rcParams['axes.color_cycle']
+    points = []
+    for i, color in enumerate(colors):
+        fig.plugins.append(
+            plugins.PointLabelTooltip(ax.plot(i, 0, 'o')[0], [color]))
+    ax.set_xlim(-1, len(colors) + 1)
+
+    return fig
+
+if __name__ == '__main__':
+    fig = main()
+    fig_to_d3(fig)
+


### PR DESCRIPTION
I have identified what could be a bug in PointLabelTooltip and I have tried to fix it in this pull request. The PR also contains a new test, test_plot_w_tooltips_labels.py, to detect the bug.

Thanks for this great package!
