### PR TITLE
ENH: Add line Tooltips

### DIFF
--- a/test_plots/test_plot_w_line_tooltips.py
+++ b/test_plots/test_plot_w_line_tooltips.py
@@ -1,0 +1,17 @@
+"""Plot to test line styles"""
+import matplotlib.pyplot as plt
+import numpy as np
+from mpld3 import plugins, fig_to_d3
+
+def main():
+    fig, ax = plt.subplots()
+    line, = ax.plot([0, 1, 3, 8, 5], '-')
+    fig.plugins = [plugins.LineLabelTooltip(line, 'Line A')]
+    ax.set_title('Line with Tooltip')
+
+    return fig
+
+if __name__ == '__main__':
+    fig = main()
+    fig_to_d3(fig)
+


### PR DESCRIPTION
Closes #42 

This adds `LineLabelTooltip`, which is similar to `PointLabelTooltip`. Test plot included.

Like `PointLabelTooltip`, it accepts one `Line2D` object. Unlike `PointLabelTooltip` the label is not optional, and it  should be a single string. See docstring.
