### PR TITLE
BUG: make html tooltips work in ipython notebook

### DIFF
--- a/mpld3/plugins.py
+++ b/mpld3/plugins.py
@@ -229,8 +229,8 @@ class PointHTMLTooltip(PluginBase):
 
 
     FIG_JS = jinja2.Template("""
-    var tooltip = fig.root.append("div")
-                    .attr("class", "tooltip")
+    var tooltip = d3.select("body").append("div")
+                    .attr("class", "mpld3-tooltip")
                     .style("position", "absolute")
                     .style("z-index", "10")
                     .style("visibility", "hidden");
@@ -245,7 +245,7 @@ class PointHTMLTooltip(PluginBase):
                              .style("visibility", "visible");})
         .on("mousemove", function(d, i){
                            tooltip
-                             .style("top", (event.pageY-{{ voffset }})+"px")
+                             .style("top", (event.pageY+{{ voffset }})+"px")
                              .style("left",(event.pageX+{{ hoffset }})+"px");})
         .on("mouseout",  function(d, i){
                            tooltip


### PR DESCRIPTION
Relatively simple to fix:  class tooltip is already taken, so use something else.  And the tooltip div needs to be in the top-level html element, so that absolute positioning is indeed absolute.

This also makes voffset work like I meant for it to.
