### PR TITLE
BUG: tooltips in firefox

### DIFF
--- a/mpld3/plugins.py
+++ b/mpld3/plugins.py
@@ -134,8 +134,8 @@ class PointLabelTooltip(PluginBase):
                           // use this instead
                           var ctm = fig.canvas.node().getScreenCTM();
                           tooltip{{ id }}
-                             .attr('x', event.x - ctm.e - {{ hoffset }})
-                             .attr('y', event.y - ctm.f - {{ voffset }});})
+                             .attr('x', d3.event.x - ctm.e - {{ hoffset }})
+                             .attr('y', d3.event.y - ctm.f - {{ voffset }});})
         .on("mouseout", function(d, i){tooltip{{ id }}.style("visibility",
                                                              "hidden");});
     """)
@@ -246,8 +246,8 @@ class PointHTMLTooltip(PluginBase):
                              .style("visibility", "visible");})
         .on("mousemove", function(d, i){
                            tooltip
-                             .style("top", (event.pageY+{{ voffset }})+"px")
-                             .style("left",(event.pageX+{{ hoffset }})+"px");})
+                             .style("top", (d3.event.pageY+{{ voffset }})+"px")
+                             .style("left",(d3.event.pageX+{{ hoffset }})+"px");})
         .on("mouseout",  function(d, i){
                            tooltip
                              .style("visibility", "hidden");});
@@ -305,8 +305,8 @@ class LineLabelTooltip(PluginBase):
                           // use this instead
                           var ctm = fig.canvas.node().getScreenCTM();
                           tooltip{{ id }}
-                             .attr('x', event.x - ctm.e - {{ hoffset }})
-                             .attr('y', event.y - ctm.f - {{ voffset }});})
+                             .attr('x', d3.event.x - ctm.e - {{ hoffset }})
+                             .attr('y', d3.event.y - ctm.f - {{ voffset }});})
         .on("mouseout", function(d, i){tooltip{{ id }}.style("visibility",
                                                              "hidden");});
     """)


### PR DESCRIPTION
event is not defined in firefox, it seems,
but d3.event is a simple workaround
