### PR TITLE
Fix _mpld3_setup.py for python > 3.3

### DIFF
--- a/_mpld3_setup.py
+++ b/_mpld3_setup.py
@@ -24,7 +24,7 @@ SUBMODULE_SYNC_PATHS = [('mplexporter/mplexporter', 'mpld3/')]
 def get_version():
     """Get the version info from the mpld3 package without importing it"""
     with open(os.path.join("mpld3", "__about__.py"), "r") as init_file:
-        exec(compile(init_file.read(), 'mpld3/__about__.py', 'exec'))
+        exec(compile(init_file.read(), 'mpld3/__about__.py', 'exec'), globals())
     try:
         return __version__
     except NameError:
@@ -160,7 +160,7 @@ class UpdateSubmodules(Command):
 BUILD_WARNING = """
 # It appears that the javascript sources may have been modified.
 # If this is the case, then the JS libraries should be rebuilt.
-# Please run 
+# Please run
 #   python setup.py buildjs
 # to re-build the javascript libraries.
 # This requires npm to be installed: see CONTRIBUTING.md for details.
@@ -170,7 +170,7 @@ BUILD_WARNING = """
 
 VERSION_ERROR = """
 # Javascript libraries for mpld3 version {0} are missing.
-# Please run 
+# Please run
 #   python setup.py buildjs
 # to re-build the javascript libraries.
 # This requires npm to be installed: see CONTRIBUTING.md for details.


### PR DESCRIPTION
Hi Jake,
First of all thanks for mpld3!

This PR solves a problem I'm having while trying to install it under python 3.3.

PS: I'm having some issues to [package](https://build.opensuse.org/package/show/home:ocefpaf/python3-mpld3) mpld3 for openSUSE due to the complex submodule scheme you chose.

It is nice, at least for packagers, that the submodules are not updated (nor checked/touched) at setup.py.  It would be preferable that they became a separated module, making it a dependency.

If that is not possible, an alternative is creating an if/clause inside setup.py that do not touch the submodules if one is not installing from a repository.  Making updating the submodules a packagers responsibility and not something that happens automagically.
