### PR TITLE
No get_matrix?

### DIFF
--- a/mpld3/mpld3renderer.py
+++ b/mpld3/mpld3renderer.py
@@ -193,7 +193,10 @@ class MPLD3Renderer(Renderer):
                       zorder=styles['zorder'])
 
         def affine_convert(t):
-            m = t.get_matrix()
+            if hasattr(t,'get_matrix'):
+                m = t.get_matrix()
+            else:
+                m = t
             return m[0, :2].tolist() + m[1, :2].tolist() + m[2, :2].tolist()
 
         pathsdict = self.add_data(offsets, "offsets")


### PR DESCRIPTION
If I try running this example:
http://mpld3.github.io/examples/custom_plugin.html

I get the following exception:

```
Traceback (most recent call last):
  File "<ipython-input-1-1cbf17305308>", line 72, in <module>
    mpld3.show()
  File "/Users/adam/virtual-python/lib/python2.7/site-packages/mpld3-0.2git-py2.7.egg/mpld3/_display.py", line 325, in show
    html = fig_to_html(fig, **kwargs)
  File "/Users/adam/virtual-python/lib/python2.7/site-packages/mpld3-0.2git-py2.7.egg/mpld3/_display.py", line 230, in fig_to_html
    Exporter(renderer, close_mpl=False, **kwargs).run(fig)
  File "/Users/adam/virtual-python/lib/python2.7/site-packages/mpld3-0.2git-py2.7.egg/mpld3/mplexporter/exporter.py", line 49, in run
    self.crawl_fig(fig)
  File "/Users/adam/virtual-python/lib/python2.7/site-packages/mpld3-0.2git-py2.7.egg/mpld3/mplexporter/exporter.py", line 116, in crawl_fig
    self.crawl_ax(ax)
  File "/Users/adam/virtual-python/lib/python2.7/site-packages/mpld3-0.2git-py2.7.egg/mpld3/mplexporter/exporter.py", line 138, in crawl_ax
    self.draw_collection(ax, collection)
  File "/Users/adam/virtual-python/lib/python2.7/site-packages/mpld3-0.2git-py2.7.egg/mpld3/mplexporter/exporter.py", line 258, in draw_collection
    mplobj=collection)
  File "/Users/adam/virtual-python/lib/python2.7/site-packages/mpld3-0.2git-py2.7.egg/mpld3/mpld3renderer.py", line 202, in draw_path_collection
    for t in path_transforms]
  File "/Users/adam/virtual-python/lib/python2.7/site-packages/mpld3-0.2git-py2.7.egg/mpld3/mpld3renderer.py", line 196, in affine_convert
    m = t.get_matrix()
AttributeError: 'numpy.ndarray' object has no attribute 'get_matrix'
```

This could well be a problem with my setup, but I think `t` should be a matplotlib transform object rather than an array... I don't know why that's happening.
