### PR TITLE
ENH: use https by default for javascript urls

### DIFF
--- a/mpld3/_display.py
+++ b/mpld3/_display.py
@@ -166,7 +166,7 @@ def fig_to_dict(fig, d3_url=None, mpld3_url=None,
 
 
 def fig_to_html(fig, d3_url=None, mpld3_url=None, no_extras=False,
-                template_type="general", figid=None, **kwargs):
+                template_type="general", figid=None, use_http=False, **kwargs):
     """Output html representation of the figure
 
     Parameters
@@ -197,6 +197,8 @@ def fig_to_html(fig, d3_url=None, mpld3_url=None, no_extras=False,
     figid : string (optional)
         The html/css id of the figure div, which must not contain spaces.
         If not specified, a random id will be generated.
+    use_http : boolean (optional)
+        If true, use http:// instead of https:// for d3_url and mpld3_url.
 
     **kwargs :
         Additional keyword arguments passed to mplexporter.Exporter
@@ -220,6 +222,10 @@ def fig_to_html(fig, d3_url=None, mpld3_url=None, no_extras=False,
     # TODO: allow fig to be a list of figures?
     d3_url = d3_url or urls.D3_URL
     mpld3_url = mpld3_url or urls.MPLD3_URL
+
+    if use_http:
+        d3_url = d3_url.replace('https://', 'http://')
+        mpld3_url = mpld3_url.replace('https://', 'http://')
 
     if figid is None:
         figid = 'fig_' + get_id(fig) + str(int(random.random() * 1E10))

--- a/mpld3/urls.py
+++ b/mpld3/urls.py
@@ -6,8 +6,8 @@ import warnings
 __all__ = ["D3_URL", "MPLD3_URL", "MPLD3MIN_URL",
            "D3_LOCAL", "MPLD3_LOCAL", "MPLD3MIN_LOCAL"]
 
-WWW_JS_DIR = "http://mpld3.github.io/js/"
-D3_URL = "http://d3js.org/d3.v3.min.js"
+WWW_JS_DIR = "https://mpld3.github.io/js/"
+D3_URL = WWW_JS_DIR + "d3.v3.min.js"
 MPLD3_URL = WWW_JS_DIR + "mpld3.v{0}.js".format(__version__)
 MPLD3MIN_URL = WWW_JS_DIR + "mpld3.v{0}.min.js".format(__version__)
 


### PR DESCRIPTION
This makes mpld3 "just work" in ipython sessions that are served securely via https, without breaking plots loaded locally via "file://" urls.

Thanks to @aebrahim for a bug fix which I took from PR #124.

This closes Issue #115.
