### PR TITLE
fix weird bug where elements in ax.collections weren't Affine2D objects but

### DIFF
--- a/mpld3/mpld3renderer.py
+++ b/mpld3/mpld3renderer.py
@@ -2,7 +2,6 @@ import random
 import json
 import jinja2
 import itertools
-import pdb
 
 import numpy as np
 


### PR DESCRIPTION
just matrices, resulting in an AttributeError on t.get_transforms()

Was trying to get the scatter tooltips to work, was getting an "AttributeError: numpy.array does not have attribute get_transforms", hunted down the bug and for some reason my plotter wasn't returning Affine2D objects but instead just matrices. I couldn't figure out why, it didn't have anything to do with the data size. But this seems to work!
