### PR TITLE
use absolute path for nbextensions

### DIFF
--- a/mpld3/utils.py
+++ b/mpld3/utils.py
@@ -81,7 +81,8 @@ def write_js_libs(location=None, d3_src=None, mpld3_src=None):
 
     if nbextension:
         install_nbextension([d3_src, mpld3_src])
-        prefix = 'nbextensions/'
+        # this will not work if a url prefix is added
+        prefix = '/nbextensions/'
     else:
         # IPython < 2.0 or explicit path.
         # This won't work if users have changed the kernel directory.


### PR DESCRIPTION
This isn't really the right way to do it, but it should work for the vast majority of cases (anything without a custom url prefix) while I figure out how to do it properly.

ref: #130
