### PR TITLE
Lowercase spelling of mpld3 on docs frontpage

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -10,7 +10,7 @@
     <script type="text/javascript" src="_static/banner_data.js"></script>
 
 
-MPLD3
+mpld3
 =====
 The mpld3 project brings together `Matplotlib <http://www.matplotlib.org>`_,
 the popular Python-based graphing library, and `D3js <http://d3js.org>`_,


### PR DESCRIPTION
Most of our docs already use lowercase spelling.
Moreover this is more consistent with the logo,
which also uses lowercase letters.
