### PR TITLE
Use CamelCase spelling for JavaScript in docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,12 +1,12 @@
 # Contributing
 
 The [mpld3](https://mpld3.github.io) project welcomes new contributors.
-The package contains both javascript code and Python code, which require slightly different development setups. Details are described below.
+The package contains both JavaScript code and Python code, which require slightly different development setups. Details are described below.
 
 ## General guidelines
 
 Code contribution is done via github. You can fork and clone the source from the [mpld3 github page](http://github.com/jakevdp/mpld3).
-Whether you are working on the Javascript side, the Python side, or both, we recommend doing the following (for information about how to use GitHub, please see the [GitHub help page](https://help.github.com/)):
+Whether you are working on the JavaScript side, the Python side, or both, we recommend doing the following (for information about how to use GitHub, please see the [GitHub help page](https://help.github.com/)):
 
 1. Register for a GitHub account.
 
@@ -16,11 +16,11 @@ Whether you are working on the Javascript side, the Python side, or both, we rec
 
          [~]$ git checkout -b my-feature-name
 
-4. Modify the Python and/or Javascript code to implement your new feature
+4. Modify the Python and/or JavaScript code to implement your new feature
 
 5. Add tests and/or examples for your feature if applicable (see instructions below)
 
-6. Run javascript and/or Python unit tests and make sure they pass (see instructions below)
+6. Run JavaScript and/or Python unit tests and make sure they pass (see instructions below)
 
 7. Push your new branch to your fork on GitHub: e.g.
 
@@ -52,37 +52,37 @@ Once the submodule is fetched, it needs to be synced from its location at ``./mp
 Because mpld3 is a pure Python package, there are no compiled extensions to build, and it can be built and used locally.
 
 
-## Building the Javascript code
+## Building the JavaScript code
 
-The javascript portion of mpld3 is built from source using the ``smash`` and ``uglify`` tools that are part of [node.js](http://nodejs.org/).
-The benefit of this approach is that the code can be organized, validated, and tested before being automatically formatted and compiled into the final javascript library.
+The JavaScript portion of mpld3 is built from source using the ``smash`` and ``uglify`` tools that are part of [node.js](http://nodejs.org/).
+The benefit of this approach is that the code can be organized, validated, and tested before being automatically formatted and compiled into the final JavaScript library.
 
-Because of this build process, any modification of the javascript source requires the installation of [npm](https://www.npmjs.org/).
+Because of this build process, any modification of the JavaScript source requires the installation of [npm](https://www.npmjs.org/).
 Once the npm executable is installed on your system, run
 
     [~]$ npm install
 
 in the main directory to set up the development environment.
-This install command will parse the file ``package.json``, and from this information, create a directory ``node_modules`` which contains the tools for building and testing the javascript side of mpld3.
+This install command will parse the file ``package.json``, and from this information, create a directory ``node_modules`` which contains the tools for building and testing the JavaScript side of mpld3.
 
-Though you may be tempted to modify the javascript in ``mpld3/js/`` directly, **this is not a good idea** because these files are overwritten in the build process.
+Though you may be tempted to modify the JavaScript in ``mpld3/js/`` directly, **this is not a good idea** because these files are overwritten in the build process.
 Instead, modify the sources in the ``src/`` directory, and then run
 
     [~]$ python setup.py buildjs
 
 The built libraries will be saved to ``mpld3/js/mpld3.v($VERSION).js`` and ``mpld3/js/mpld3.v($VERSION).min.js``, where ``($VERSION)`` is replaced by the current version defined in ``mpld3/__about__.py``. The mpld3 Python package will link to the matching mpld3 version.
 
-When contributing a javascript patch or enhancement, please include **both the javascript sources and the built ``mpld3/js/*.js`` libraries**.
-This is important so that users who don't wish to modify the javascript can install the package without needing ``npm`` and ``nodejs``.
-Additionally, if possible please add javascript unit tests of your new functionality to the ``test`` directory (see details below).
+When contributing a JavaScript patch or enhancement, please include **both the JavaScript sources and the built ``mpld3/js/*.js`` libraries**.
+This is important so that users who don't wish to modify the JavaScript can install the package without needing ``npm`` and ``nodejs``.
+Additionally, if possible please add JavaScript unit tests of your new functionality to the ``test`` directory (see details below).
 
 
 ## Testing the package
 Currently, mpld3 has three different levels of testing, though we hope to streamline this in the future:
 
-- There are automated Javascript tests using [vows](https://www.npmjs.org/package/vows). These should be run if you modify the javascript code.
+- There are automated JavaScript tests using [vows](https://www.npmjs.org/package/vows). These should be run if you modify the JavaScript code.
 - There are automated Python tests using [nose](http://nose.readthedocs.org). These should be run if you modify the Python code.
-- There are manual plot tests using the ``visualize_tests.py`` script in the repository. These should be run if either the Python or Javascript code is modified.
+- There are manual plot tests using the ``visualize_tests.py`` script in the repository. These should be run if either the Python or JavaScript code is modified.
 
 
 ### Testing Python with nose
@@ -99,15 +99,15 @@ These tests are in various directories within the Python source tree, for exampl
 In addition to running nosetests, you should check any Python modifications using the ``visualize_tests.py`` script, described below.
 
 
-### Testing Javascript with vows
-Like the Python nosetests, there is a minimal test suite for the mpld3 javascript which is controlled with ``npm`` using the ``vows`` package.
+### Testing JavaScript with vows
+Like the Python nosetests, there is a minimal test suite for the mpld3 JavaScript which is controlled with ``npm`` using the ``vows`` package.
 The tests can be executed via
 
     [~]$ npm test
 
 This requires installation of ``npm``, which is described above.
 The tests are located in the ``test`` subdirectory of the main repository.
-In addition to running the vows tests, before submitting any javascript change, you should examine the output of ``visualize_tests.py``, as described below.
+In addition to running the vows tests, before submitting any JavaScript change, you should examine the output of ``visualize_tests.py``, as described below.
 
 
 ### Comprehensive JS/Python Test: ``visualize_tests.py``
@@ -119,7 +119,7 @@ These test plots can be viewed by running
 
 This will generate a file ``test_plots.html`` containing embedded pngs and mpld3 scripts.
 If your system allows it, the command will finish by automatically opening this file in a web browser.
-It is important to open the javascript console (see your browser documentation) and check for errors in the javascript execution as you interact with the plots.
+It is important to open the JavaScript console (see your browser documentation) and check for errors in the JavaScript execution as you interact with the plots.
 
-Note that the ``--local`` argument in the above command assures that the local copies of the javascript libraries are used (i.e. the versions in ``mpld3/js/*.js``).
+Note that the ``--local`` argument in the above command assures that the local copies of the JavaScript libraries are used (i.e. the versions in ``mpld3/js/*.js``).
 If you omit this argument, the test plots will be run using the mpld3/d3 library versions available on the web at http://mpld3.github.io.

--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -24,7 +24,7 @@ General
 
 - **Can I use mpld3 without matplotlib?**
 
-  Yes! The client-side interface of mpld3 is a pure javascript library, which builds figures based on a well-defined JSON specification. This specification was designed with matplotlib in mind, but there's nothing stopping you from generating the JSON from another source, or even editing it by hand. Unfortunately, at the moment, this JSON spec is not well-documented, but we hope to address that in the future.
+  Yes! The client-side interface of mpld3 is a pure JavaScript library, which builds figures based on a well-defined JSON specification. This specification was designed with matplotlib in mind, but there's nothing stopping you from generating the JSON from another source, or even editing it by hand. Unfortunately, at the moment, this JSON spec is not well-documented, but we hope to address that in the future.
 
 - **Can mpld3 render to HTML5 canvas rather than SVG?**
 
@@ -46,24 +46,24 @@ IPython Notebook
 
 - **I'm using SSL to have a secure connection and/or make a remote IPython notebook play nice with Windows 8. How do I get mpld3 to work?**
 
-  Default browser security settings do not allow secure web pages to load javascript libraries from an insecure server. To work around this, simply specify alternative urls for d3 and mpld3 when you call :func:`mpld3.enable_notebook`. For example::
+  Default browser security settings do not allow secure web pages to load JavaScript libraries from an insecure server. To work around this, simply specify alternative urls for d3 and mpld3 when you call :func:`mpld3.enable_notebook`. For example::
 
     mpld3.enable_notebook(d3_url='//mpld3.github.io/js/d3.v3.min.js',
                           mpld3_url='//mpld3.github.io/js/mpld3.v0.1.js')
 
 
-Javascript
+JavaScript
 ----------
 
-- **Where is the mpld3 javascript library located?**
+- **Where is the mpld3 JavaScript library located?**
 
   There is a local copy of the mpld3 library bundled with the package, which you can find in ``mpld3/js/mpld3.v0.2.js`` where ``v0.2`` indicates the library version, and matches the version of the mpld3 Python package. This local copy is used with the command ``mpld3.show``, so that no internet connection is needed. Online copies of the library can be found at, e.g. http://mpld3.github.io/js/mpld3.v0.2.js. This is automatically used within the IPython notebook, and commands like :func:`mpld3.save_html`, :func:`mpld3.fig_to_html`, etc.
 
 - **How can I use mpld3 without an internet connection?**
 
-  To use mpld3 without an internet connection, you need to use a local version of the mpld3 and d3 libraries. Outside the IPython notebook, you can use the :func:`mpld3.show()` function, which automatically uses local copies of the javascript libraries.
+  To use mpld3 without an internet connection, you need to use a local version of the mpld3 and d3 libraries. Outside the IPython notebook, you can use the :func:`mpld3.show()` function, which automatically uses local copies of the JavaScript libraries.
 
-  Inside the IPython notebook, both the :func:`mpld3.enable_notebook` and :func:`mpld3.display` functions take a boolean keyword ``local``. Setting this to ``True`` will copy the mpld3 and d3 javascript libraries to the notebook directory, and will use the appropriate path within IPython (``/files/*.js``) to load the libraries. Be aware, though, that currently ``local=True`` will fail for some use-cases of the notebook. See the documentation of the above functions for details.
+  Inside the IPython notebook, both the :func:`mpld3.enable_notebook` and :func:`mpld3.display` functions take a boolean keyword ``local``. Setting this to ``True`` will copy the mpld3 and d3 JavaScript libraries to the notebook directory, and will use the appropriate path within IPython (``/files/*.js``) to load the libraries. Be aware, though, that currently ``local=True`` will fail for some use-cases of the notebook. See the documentation of the above functions for details.
 
 
 Troubleshooting
@@ -71,15 +71,15 @@ Troubleshooting
 
 - **Why is the notebook behavior breaking when I update mpld3?**
 
-  Short answer: you must make sure that your notebook is pointing to the correct javascript libraries. The best way to do this is to follow the following steps:
+  Short answer: you must make sure that your notebook is pointing to the correct JavaScript libraries. The best way to do this is to follow the following steps:
 
   1. Clear all the output in the notebook (This can be done via the toolbar, with Cell -> All Output -> Clear)
   2. Save your notebook
   3. Close the notebook window
   4. Re-open the notebook window
 
-  Long answer: mpld3 is a bit more complicated than the average Python package, especially when it is used in the IPython notebook. You must keep in mind that there are two distinct components which interact: the Python library, and the javascript library.
+  Long answer: mpld3 is a bit more complicated than the average Python package, especially when it is used in the IPython notebook. You must keep in mind that there are two distinct components which interact: the Python library, and the JavaScript library.
 
-  If you have an IPython notebook that uses mpld3 and you update the library, you must make sure that your notebook is using **both** the updated Python package and the updated Javascript package. Using the updated Python package can be as simple as restarting the kernel and running the notebook again. However, because the javascript library is referenced in the output cells, loaded on page load, and cached by the browser, it is very easy to find yourself using old versions of the Javascript library even if you're using the newer version of the Python library.
+  If you have an IPython notebook that uses mpld3 and you update the library, you must make sure that your notebook is using **both** the updated Python package and the updated JavaScript package. Using the updated Python package can be as simple as restarting the kernel and running the notebook again. However, because the JavaScript library is referenced in the output cells, loaded on page load, and cached by the browser, it is very easy to find yourself using old versions of the JavaScript library even if you're using the newer version of the Python library.
 
   If you have any strange notebook issues after updating mpld3, then it is best to wipe the output, restart the browser, and start again from a clean slate. This can be done using the steps outlined above.

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -14,7 +14,7 @@ mpld3
 =====
 The mpld3 project brings together `Matplotlib <http://www.matplotlib.org>`_,
 the popular Python-based graphing library, and `D3js <http://d3js.org>`_,
-the popular Javascript library for creating interactive data visualizations
+the popular JavaScript library for creating interactive data visualizations
 for the web.  The result is a simple API for exporting your matplotlib
 graphics to HTML code which can be used within the browser, within standard
 web pages, blogs, or tools such as the

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -27,10 +27,10 @@ When installing from the gihub source, use::
     [~]$ python setup.py submodule
     [~]$ python setup.py install
 
-Building Javascript Sources
+Building JavaScript Sources
 ---------------------------
-A core piece of the mpld3 package are the javascript libraries, which are located in the package in the ``mpld3/js/`` directory.
-The ``mpld3.*.js`` is automatically constructed from a number of source javascript files; if you modify these sources, the libraries must be re-built before mpld3 is installed. For more information, please refer to ``CONTRIBUTING.md``, found in the project repository.
+A core piece of the mpld3 package are the JavaScript libraries, which are located in the package in the ``mpld3/js/`` directory.
+The ``mpld3.*.js`` is automatically constructed from a number of source JavaScript files; if you modify these sources, the libraries must be re-built before mpld3 is installed. For more information, please refer to ``CONTRIBUTING.md``, found in the project repository.
 
 Dependencies
 ------------

--- a/doc/plugins.rst
+++ b/doc/plugins.rst
@@ -2,4 +2,4 @@
 
 Plugins
 =======
-Plugins in mpld3 offer a means of defining new interactive behaviors on matplotlib plots through the use of javascript and D3js. More information is available in the :ref:`notebook-examples`.
+Plugins in mpld3 offer a means of defining new interactive behaviors on matplotlib plots through the use of JavaScript and D3js. More information is available in the :ref:`notebook-examples`.

--- a/doc/quickstart.rst
+++ b/doc/quickstart.rst
@@ -34,12 +34,12 @@ and D3js. See some examples of these being used in the :ref:`example-gallery`.
 
 :func:`fig_to_html`
     This is the core routine which takes a figure and constructs a string of
-    html and javascript which can be embedded in any webpage.
+    html and JavaScript which can be embedded in any webpage.
 
 :func:`fig_to_dict`
     This routine converts a matplotlib image to a JSON-serializable dictionary,
     which can be loaded into an appropriate HTML page and rendered via the
-    mpld3 Javascript library.  Note that custom plugins which are not built
+    mpld3 JavaScript library.  Note that custom plugins which are not built
     into mpld3 will not be part of the JSON serialization.
 
 :func:`show`
@@ -66,7 +66,7 @@ See some examples of these being used in the :ref:`notebook-examples`.
     This function will adjust the IPython notebook display properties so that
     mpld3 will be used to display every figure, without having to call
     :func:`display` each time. This is useful if you want every figure to be
-    automatically embedded in the notebook as an interactive javascript figure.
+    automatically embedded in the notebook as an interactive JavaScript figure.
     This function should be called *after* setting ``%matplotlib inline``
     mode within the notebook: see the `IPython documentation
     <http://ipython.org/ipython-doc/dev/interactive/notebook.html#plotting>`_


### PR DESCRIPTION
The official spelling is JavaScript, with a capital J
and a capital S.
See https://developer.mozilla.org/en-US/docs/Web/JavaScript

Only change the documentation for now, in order not to break
any code.
