### PR TITLE
a html tooltip for Line2d objects

### DIFF
--- a/mpld3/plugins.py
+++ b/mpld3/plugins.py
@@ -304,7 +304,9 @@ class PointHTMLTooltip(PluginBase):
     HtmlTooltipPlugin.prototype = Object.create(mpld3.Plugin.prototype);
     HtmlTooltipPlugin.prototype.constructor = HtmlTooltipPlugin;
     HtmlTooltipPlugin.prototype.requiredProps = ["id"];
-    HtmlTooltipPlugin.prototype.defaultProps = {labels:null, hoffset:0, voffset:10};
+    HtmlTooltipPlugin.prototype.defaultProps = {labels:null,
+                                                hoffset:0,
+                                                voffset:10};
     function HtmlTooltipPlugin(fig, props){
         mpld3.Plugin.call(this, fig, props);
     };
@@ -323,9 +325,9 @@ class PointHTMLTooltip(PluginBase):
                               tooltip.html(labels[i])
                                      .style("visibility", "visible");})
            .on("mousemove", function(d, i){
-                    tooltip
-                      .style("top", d3.event.pageY + this.props.voffset + "px")
-                      .style("left",d3.event.pageX + this.props.hoffset + "px");
+                  tooltip
+                    .style("top", d3.event.pageY + this.props.voffset + "px")
+                    .style("left",d3.event.pageX + this.props.hoffset + "px");
                  }.bind(this))
            .on("mouseout",  function(d, i){
                            tooltip.style("visibility", "hidden");});
@@ -371,7 +373,7 @@ class LineHTMLTooltip(PluginBase):
     >>> from mpld3 import fig_to_html, plugins
     >>> fig, ax = plt.subplots()
     >>> lines = ax.plot(range(10))
-    >>> label = '<h1>line {title}</h1>'.format(title='A') 
+    >>> label = '<h1>line {title}</h1>'.format(title='A')
     >>> plugins.connect(fig, LineHTMLTooltip(lines[0], label))
     >>> fig_to_html(fig)
     """
@@ -381,29 +383,31 @@ class LineHTMLTooltip(PluginBase):
     LineHTMLTooltip.prototype = Object.create(mpld3.Plugin.prototype);
     LineHTMLTooltip.prototype.constructor = LineHTMLTooltip;
     LineHTMLTooltip.prototype.requiredProps = ["id"];
-    LineHTMLTooltip.prototype.defaultProps = {label:null, hoffset:0, voffset:10};
+    LineHTMLTooltip.prototype.defaultProps = {label:null,
+                                              hoffset:0,
+                                              voffset:10};
     function LineHTMLTooltip(fig, props){
         mpld3.Plugin.call(this, fig, props);
     };
 
     LineHTMLTooltip.prototype.draw = function(){
-        var obj = mpld3.get_element(this.props.id, this.fig);     
+        var obj = mpld3.get_element(this.props.id, this.fig);
         var label = this.props.label
         var tooltip = d3.select("body").append("div")
                     .attr("class", "mpld3-tooltip")
                     .style("position", "absolute")
                     .style("z-index", "10")
                     .style("visibility", "hidden");
-        
+
         obj.elements()
            .on("mouseover", function(d, i){
                                tooltip.html(label)
                                       .style("visibility", "visible");
                                      })
             .on("mousemove", function(d, i){
-                    tooltip
-                       .style("top", d3.event.pageY + this.props.voffset + "px")
-                      .style("left",d3.event.pageX + this.props.hoffset + "px");
+                  tooltip
+                    .style("top", d3.event.pageY + this.props.voffset + "px")
+                    .style("left",d3.event.pageX + this.props.hoffset + "px");
                  }.bind(this))
            .on("mouseout",  function(d, i){
                            tooltip.style("visibility", "hidden");})
@@ -411,7 +415,7 @@ class LineHTMLTooltip(PluginBase):
     """
 
     def __init__(self, line, label=None,
-                 hoffset=0, voffset=10, 
+                 hoffset=0, voffset=10,
                  css=None):
         self.line = line
         self.label = label

--- a/mpld3/test_plots/test_line_HTMLtooltips.py
+++ b/mpld3/test_plots/test_line_HTMLtooltips.py
@@ -4,10 +4,11 @@ import matplotlib.pyplot as plt
 import mpld3
 from mpld3 import plugins
 
+
 def create_plot():
     fig, ax = plt.subplots()
     line, = ax.plot([0, 1, 3, 8, 5], '-', lw=5)
-    label = '<h1>Line {}</h1>'.format('A') 
+    label = '<h1>Line {}</h1>'.format('A')
     plugins.connect(fig, plugins.LineHTMLTooltip(line, label))
     ax.set_title('Line with HTML Tooltip')
     return fig


### PR DESCRIPTION
Modeled on the existing html tooltip, but now specific for Line2d
objects. I believe this resolves #44.
