### PR TITLE
TST: test mpld3.show()

### DIFF
--- a/mpld3/_display.py
+++ b/mpld3/_display.py
@@ -5,7 +5,7 @@ import jinja2
 import numpy
 import re
 import os
-from ._server import serve_and_open
+from ._server import serve
 from .utils import deprecated, get_id, write_ipynb_local_js
 from .mplexporter import Exporter
 from .mpld3renderer import MPLD3Renderer
@@ -306,7 +306,7 @@ def display(fig=None, closefig=True, local=False, **kwargs):
 
 
 def show(fig=None, ip='127.0.0.1', port=8888, n_retries=50,
-         local=True, **kwargs):
+         local=True, open_browser=True, **kwargs):
     """Open figure in a web browser
 
     Similar behavior to plt.show().  This opens the D3 visualization of the
@@ -328,6 +328,8 @@ def show(fig=None, ip='127.0.0.1', port=8888, n_retries=50,
     local : bool, default = True
         if True, use the local d3 & mpld3 javascript versions, within the
         js/ folder.  If False, use the standard urls.
+    open_browser : bool (optional)
+        if True (default), then open a web browser to the given HTML
     **kwargs :
         additional keyword arguments are passed through to :func:`fig_to_html`
 
@@ -351,7 +353,7 @@ def show(fig=None, ip='127.0.0.1', port=8888, n_retries=50,
         import matplotlib.pyplot as plt
         fig = plt.gcf()
     html = fig_to_html(fig, **kwargs)
-    serve_and_open(html, ip=ip, port=port, n_retries=n_retries, files=files)
+    serve(html, ip=ip, port=port, n_retries=n_retries, files=files, open_browser=open_browser)
 
 
 def enable_notebook(local=False, **kwargs):

--- a/mpld3/_server.py
+++ b/mpld3/_server.py
@@ -66,9 +66,10 @@ def find_open_port(ip, port, n=50):
     raise ValueError("no open ports found")
 
 
-def serve_and_open(html, ip='127.0.0.1', port=8888, n_retries=50, files=None,
-                   ipython_warning=True):
-    """Start a server serving the given HTML, and open a browser
+def serve(html, ip='127.0.0.1', port=8888, n_retries=50, files=None,
+          ipython_warning=True, open_browser=True):
+    """Start a server serving the given HTML, and (optionally) open a
+    browser
 
     Parameters
     ----------
@@ -84,6 +85,8 @@ def serve_and_open(html, ip='127.0.0.1', port=8888, n_retries=50, files=None,
         dictionary of extra content to serve
     ipython_warning : bool (optional)
         if True (default), then print a warning if this is used within IPython
+    open_browser : bool (optional)
+        if True (default), then open a web browser to the given HTML
     """
     port = find_open_port(ip, port, n_retries)
     Handler = generate_handler(html, files)
@@ -101,9 +104,10 @@ def serve_and_open(html, ip='127.0.0.1', port=8888, n_retries=50, files=None,
     print("Serving to http://{0}:{1}/    [Ctrl-C to exit]".format(ip, port))
     sys.stdout.flush()
 
-    # Use a thread to open a web browser pointing to the server
-    b = lambda: webbrowser.open('http://{0}:{1}'.format(ip, port))
-    threading.Thread(target=b).start()
+    if open_browser:
+        # Use a thread to open a web browser pointing to the server
+        b = lambda: webbrowser.open('http://{0}:{1}'.format(ip, port))
+        threading.Thread(target=b).start()
 
     try:
         srvr.serve_forever()

--- a/mpld3/tests/test_show.py
+++ b/mpld3/tests/test_show.py
@@ -1,0 +1,19 @@
+"""
+Test http server
+"""
+
+import subprocess, time
+
+python_test_code = """import mpld3; mpld3.show(open_browser=False)"""
+
+p = subprocess.Popen(['python', '-c', python_test_code])
+time.sleep(1) # wait for plot subprocess to get started
+              # TODO: use a more robust approach for this
+
+assert p.poll() is None, \
+    'polling http server should return None if it is running'
+
+# TODO: use casperjs to fetch figure from server and ensure it has
+# proper parts
+
+p.terminate()


### PR DESCRIPTION
This test runs `mpld3.show()` in a `subprocess`, and is the way I think we can do functional testing with `casperjs` eventually.  It is related to #196 and #215, but I don't think it resolves either of them.
