### PR TITLE
Fixed mpld3.show() for Python 3.4 by calling encoding() on str

### DIFF
--- a/mpld3/_server.py
+++ b/mpld3/_server.py
@@ -37,15 +37,15 @@ def generate_handler(html, files=None):
                 self.end_headers()
                 self.wfile.write("<html><head>"
                                  "<title>mpld3 plot</title>"
-                                 "</head><body>\n")
-                self.wfile.write(html)
-                self.wfile.write("</body></html>")
+                                 "</head><body>\n".encode())
+                self.wfile.write(html.encode())
+                self.wfile.write("</body></html>".encode())
             elif self.path in files:
                 content_type, content = files[self.path]
                 self.send_response(200)
                 self.send_header("Content-type", content_type)
                 self.end_headers()
-                self.wfile.write(content)
+                self.wfile.write(content.encode())
             else:
                 self.send_error(404)
 


### PR DESCRIPTION
Simple fix for python 3.4, might well break 2.x support - but CI might throw this up.
