### PR TITLE
Added test for legends on scatter plots

### DIFF
--- a/mpld3/test_plots/test_legend_scatter.py
+++ b/mpld3/test_plots/test_legend_scatter.py
@@ -1,0 +1,28 @@
+"""Plot to test legend"""
+import matplotlib.pyplot as plt
+import numpy as np
+import mpld3
+
+
+def create_plot():
+    fig, ax = plt.subplots()
+
+    x = np.linspace(0, 10, 100)
+    ax.scatter(x, np.sin(x), label='sin', alpha=0.5)
+    ax.scatter(x, np.cos(x), label='cos',  c='g', alpha=0.5)
+    ax.scatter(x[::5], 0.5 * np.sin(x[::5] + 2), c='b', label='dots')
+
+    ax.legend(fancybox=True)
+    ax.set_title("Legend Scatter test", size=20)
+
+    return fig
+
+
+def test_legend():
+    fig = create_plot()
+    html = mpld3.fig_to_html(fig)
+    plt.close(fig)
+
+
+if __name__ == "__main__":
+    mpld3.show(create_plot())


### PR DESCRIPTION
I am encountering a bug very similar to #86 and #48 when using a scatter plot, a legend, and tooltips.  The legend box is shown but the markers for the different data series are not shown.  I can recreate it by making the changes that @gabraganca made to the [tooltip example](http://mpld3.github.io/examples/scatter_tooltip.html#scatter-tooltip).  
![image](https://cloud.githubusercontent.com/assets/727375/4921006/0090c0e8-6507-11e4-970b-1baee08ffbc4.png)

It also occurs if I modify `test_plots/test_legend.py` to use scatter plots, even without tooltips.
This pull request creates `test_plots/test_legend_scatter.py` which creates similar plots using `plt.scatter`.
![image](https://cloud.githubusercontent.com/assets/727375/4921412/477708f2-650a-11e4-8227-dd7202b2945f.png)
