### PR TITLE
Fix travis 'unsatisfiable' conda error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-sudo: false
 language: python
 
 python:
@@ -19,12 +18,21 @@ before_install:
   - npm config set python python2.7
   - npm install d3 vows smash jsdom
   # then install python version to test
-  - if [ ${TRAVIS_PYTHON_VERSION:0:1} == "2" ]; then wget http://repo.continuum.io/miniconda/Miniconda-2.2.2-Linux-x86_64.sh -O miniconda.sh; else wget http://repo.continuum.io/miniconda/Miniconda3-2.2.2-Linux-x86_64.sh -O miniconda.sh; fi
-  - chmod +x miniconda.sh
-  - ./miniconda.sh -b
-  - export PATH=/home/travis/anaconda/bin:$PATH
-  # Learned the hard way: miniconda is not always up-to-date with conda.
-  - conda update --yes conda
+  - sudo apt-get update
+  # We do this conditionally because it saves us some downloading if the
+  # version is the same.
+  - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
+      wget https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh -O miniconda.sh;
+    else
+      wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
+    fi
+  - bash miniconda.sh -b -p $HOME/miniconda
+  - export PATH="$HOME/miniconda/bin:$PATH"
+  - hash -r
+  - conda config --set always_yes yes --set changeps1 no
+  - conda update -q conda
+  # Useful for debugging any issues with conda
+  - conda info -a
   # start Virtual X, so default matplotlib backend works
   - "export DISPLAY=:99.0"
   - "sh -e /etc/init.d/xvfb start"


### PR DESCRIPTION
Fix for #357.

Replaces conda part of `.travis.yml` with corresponding part of http://conda.pydata.org/docs/travis.html#the-travis-yml-file. Removes `sudo: false`.