### PR TITLE
fontsize setting, legend offset setting, text mouseover add

### DIFF
--- a/mpld3/plugins.py
+++ b/mpld3/plugins.py
@@ -455,6 +455,13 @@ class InteractiveLegendPlugin(PluginBase):
         Default is 1 (no effect), 1.5 works nicely !
     start_visible : boolean, optional (could be a list of booleans)
         defines if objects should start selected on not.
+    font_size : int, optional
+        defines legend font-size.
+        Default is 10.
+    legend_offset : list of int (length: 2)
+        defines horizontal offset and vertical offset of legend.
+        Default is (0, 0).
+
     Examples
     --------
     >>> import matplotlib.pyplot as plt
@@ -471,7 +478,9 @@ class InteractiveLegendPlugin(PluginBase):
     ...                                                      labels,
     ...                                                      alpha_unsel=0.2,
     ...                                                      alpha_over=1.5,
-    ...                                                      start_visible=True)
+    ...                                                      start_visible=True,
+    ...                                                      font_size=14,
+    ...                                                      legend_offset=(-100,20))
     >>> plugins.connect(fig, interactive_legend)
     >>> fig_to_html(fig)
     """
@@ -484,7 +493,9 @@ class InteractiveLegendPlugin(PluginBase):
     InteractiveLegend.prototype.defaultProps = {"ax":null,
                                                 "alpha_unsel":0.2,
                                                 "alpha_over":1.0,
-                                                "start_visible":true}
+                                                "start_visible":true,
+                                                "font_size": 10,
+                                                "legend_offset": [0,0]}
     function InteractiveLegend(fig, props){
         mpld3.Plugin.call(this, fig, props);
     };
@@ -492,6 +503,8 @@ class InteractiveLegendPlugin(PluginBase):
     InteractiveLegend.prototype.draw = function(){
         var alpha_unsel = this.props.alpha_unsel;
         var alpha_over = this.props.alpha_over;
+        var font_size = this.props.font_size;
+        var legend_offset = this.props.legend_offset;
 
         var legendItems = new Array();
         for(var i=0; i<this.props.labels.length; i++){
@@ -533,11 +546,11 @@ class InteractiveLegendPlugin(PluginBase):
         legend.selectAll("rect")
                 .data(legendItems)
                 .enter().append("rect")
-                .attr("height", 10)
-                .attr("width", 25)
-                .attr("x", ax.width + ax.position[0] + 25)
+                .attr("height", 0.7*font_size)
+                .attr("width", 1.6*font_size)
+                .attr("x", ax.width + ax.position[0] + 15 + legend_offset[0])
                 .attr("y",function(d,i) {
-                           return ax.position[1] + i * 25 + 10;})
+                           return ax.position[1] + i * (font_size+5) + 10 + legend_offset[1];})
                 .attr("stroke", get_color)
                 .attr("class", "legend-box")
                 .style("fill", function(d, i) {
@@ -548,11 +561,13 @@ class InteractiveLegendPlugin(PluginBase):
         legend.selectAll("text")
               .data(legendItems)
               .enter().append("text")
+              .attr("font-size", font_size)
               .attr("x", function (d) {
-                           return ax.width + ax.position[0] + 25 + 40;})
+                           return ax.width + ax.position[0] + (1.9*font_size+15) + legend_offset[0];})
               .attr("y", function(d,i) {
-                           return ax.position[1] + i * 25 + 10 + 10 - 1;})
-              .text(function(d) { return d.label });
+                           return ax.position[1] + i * (font_size+5) + 10 + (0.72*font_size-1) + legend_offset[1];})
+              .text(function(d) { return d.label })
+              .on('mouseover', over).on('mouseout', out);
 
 
         // specify the action on click
@@ -631,7 +646,7 @@ class InteractiveLegendPlugin(PluginBase):
     """
 
     def __init__(self, plot_elements, labels, ax=None,
-                 alpha_unsel=0.2, alpha_over=1., start_visible=True):
+                 alpha_unsel=0.2, alpha_over=1., start_visible=True, font_size=10, legend_offset=(0,0)):
 
         self.ax = ax
 
@@ -653,7 +668,9 @@ class InteractiveLegendPlugin(PluginBase):
                       "ax": ax,
                       "alpha_unsel": alpha_unsel,
                       "alpha_over": alpha_over,
-                      "start_visible": start_visible}
+                      "start_visible": start_visible,
+                      "font_size": font_size,
+                      "legend_offset": legend_offset}
 
     def _determine_mpld3ids(self, plot_elements):
         """


### PR DESCRIPTION
Font size and Legend offset option added to InteractiveLegendPlugin.
For example, mpld3.plugins.InteractiveLegendPlugin(fig, ..., font_size=9, legend_offset=(-550,-30))
makes below:

![image](https://cloud.githubusercontent.com/assets/19621199/23340089/d61a0d0e-fc73-11e6-967b-34920ab3b359.png)

And alpha value is set also when the legend text is overlaid.