### PR TITLE
Adding support for encoding lists in NumpyEncoder

### DIFF
--- a/mpld3/_display.py
+++ b/mpld3/_display.py
@@ -128,6 +128,12 @@ class NumpyEncoder(json.JSONEncoder):
     """ Special json encoder for numpy types """
 
     def default(self, obj):
+        try:
+            iterable = iter(obj)
+        except TypeError:
+            pass
+        else:
+            return [self.default(item) for item in iterable]
         if isinstance(obj, (numpy.int_, numpy.intc, numpy.intp, numpy.int8,
             numpy.int16, numpy.int32, numpy.int64, numpy.uint8,
             numpy.uint16,numpy.uint32, numpy.uint64)):


### PR DESCRIPTION
At the moment mpld3._display.NumpyEncoder() does not encode lists of elements. When I use your library I get the error:
"TypeError: array([ 1.]) is not JSON serializable"

This PR allows NumpyEncoder.default() to handle lists, and makes your library work for me. I would love to hear your comments.

