### PR TITLE
added targets argument to PointHTMLTooltip that lets you click on points

### DIFF
--- a/mpld3/plugins.py
+++ b/mpld3/plugins.py
@@ -284,6 +284,8 @@ class PointHTMLTooltip(PluginBase):
         The figure element to apply the tooltip to
     labels : list
         The labels for each point in points, as strings of unescaped HTML.
+    targets : list
+        The urls that each point will open when clicked.
     hoffset, voffset : integer, optional
         The number of pixels to offset the tooltip text.  Default is
         hoffset = 0, voffset = 10
@@ -306,6 +308,7 @@ class PointHTMLTooltip(PluginBase):
     HtmlTooltipPlugin.prototype.constructor = HtmlTooltipPlugin;
     HtmlTooltipPlugin.prototype.requiredProps = ["id"];
     HtmlTooltipPlugin.prototype.defaultProps = {labels:null,
+                                                target:null,
                                                 hoffset:0,
                                                 voffset:10};
     function HtmlTooltipPlugin(fig, props){
@@ -315,6 +318,7 @@ class PointHTMLTooltip(PluginBase):
     HtmlTooltipPlugin.prototype.draw = function(){
        var obj = mpld3.get_element(this.props.id);
        var labels = this.props.labels;
+       var targets = this.props.targets;
        var tooltip = d3.select("body").append("div")
                     .attr("class", "mpld3-tooltip")
                     .style("position", "absolute")
@@ -330,15 +334,18 @@ class PointHTMLTooltip(PluginBase):
                     .style("top", d3.event.pageY + this.props.voffset + "px")
                     .style("left",d3.event.pageX + this.props.hoffset + "px");
                  }.bind(this))
+           .on("mousedown.callout",  function(d, i){
+                           window.open(targets[i],"_blank");})
            .on("mouseout",  function(d, i){
                            tooltip.style("visibility", "hidden");});
     };
     """
 
-    def __init__(self, points, labels=None,
+    def __init__(self, points, labels=None, targets=None,
                  hoffset=0, voffset=10, css=None):
         self.points = points
         self.labels = labels
+        self.targets = targets
         self.voffset = voffset
         self.hoffset = hoffset
         self.css_ = css or ""
@@ -349,6 +356,7 @@ class PointHTMLTooltip(PluginBase):
         self.dict_ = {"type": "htmltooltip",
                       "id": get_id(points, suffix),
                       "labels": labels,
+                      "targets": targets,
                       "hoffset": hoffset,
                       "voffset": voffset}
 


### PR DESCRIPTION
A)  Thanks to all who put together this package!  I just started trying to create a project making plots on a django site and coming from a mpl background, this made it SO EASY!  So, again, thanks.  I realize this package has fallen on hard times, but thanks!

B)  I mistakenly made the change in my master branch.  I had created a clickable-scatter-plots branch, but forgot to switch branches before checked in.  Should I start over?

C)  The pull request adds a "targets" argument as @aflaxman suggested in #323 .
I found that #330 ClickableHTML wasn't doing what I wanted it to do (open another webpage in a new tab).
It seemed like adding the argument to an existing Tooltip was better than adding a whole other plugin.

D)  In the visualize_tests.py, the HTMLTooltip still works and nothing bad happens when you click on points. 

E) See [my pythonanywhere page](http://stinsong4100.pythonanywhere.com/plots) for example of how this works.

F) I would be interested in linking my github repository that uses mpld3 in django to this site.  It seems like there are several issues asking about how to insert mpld3 plots into django templates, so a tutorial from mpld3 would be good.

G) I did get a Fail in the nosetests that I'm hoping I didn't create.


```======================================================================
FAIL: mpld3.tests.test_elements.test_scatter
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/stinson/anaconda/lib/python3.6/site-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/Users/stinson/src/mpld3/mpld3/tests/test_elements.py", line 76, in test_scatter
    [[6.085806194501846, 0.0, 0.0, 6.085806194501846, 0.0, 0.0]])
  File "/Users/stinson/anaconda/lib/python3.6/site-packages/numpy/testing/utils.py", line 317, in assert_equal
    assert_equal(actual[k], desired[k], 'item=%r\n%s' % (k, err_msg), verbose)
  File "/Users/stinson/anaconda/lib/python3.6/site-packages/numpy/testing/utils.py", line 317, in assert_equal
    assert_equal(actual[k], desired[k], 'item=%r\n%s' % (k, err_msg), verbose)
  File "/Users/stinson/anaconda/lib/python3.6/site-packages/numpy/testing/utils.py", line 381, in assert_equal
    raise AssertionError(msg)
AssertionError: 
Items are not equal:
item=0
item=0

 ACTUAL: 7.607257743127308
 DESIRED: 6.085806194501846
```