### PR TITLE
Generalised conversion of numpy types

### DIFF
--- a/mpld3/_display.py
+++ b/mpld3/_display.py
@@ -134,13 +134,8 @@ class NumpyEncoder(json.JSONEncoder):
             pass
         else:
             return [self.default(item) for item in iterable]
-        if isinstance(obj, (numpy.int_, numpy.intc, numpy.intp, numpy.int8,
-            numpy.int16, numpy.int32, numpy.int64, numpy.uint8,
-            numpy.uint16,numpy.uint32, numpy.uint64)):
-            return int(obj)
-        elif isinstance(obj, (numpy.float_, numpy.float16, numpy.float32, 
-            numpy.float64)):
-            return float(obj)
+        if isinstance(obj, numpy.generic):
+            return numpy.asscalar(obj)
         elif isinstance(obj, (numpy.ndarray,)):
             return obj.tolist()
         return json.JSONEncoder.default(self, obj)


### PR DESCRIPTION
Generalised conversion of numpy types in NumpyEncoder. `isinstance(obj, numpy.generic)` will avoid numpy arrays being coerced. Unlikely bonus is that this should make the encoder resilient to unforeseen  numpy types that appear in the future. This will also allow datetimes, timedeltas etc to be processed.