### PR TITLE
Fix numpy deprecation warning

### DIFF
--- a/mpld3/_display.py
+++ b/mpld3/_display.py
@@ -135,7 +135,7 @@ class NumpyEncoder(json.JSONEncoder):
         else:
             return [self.default(item) for item in iterable]
         if isinstance(obj, numpy.generic):
-            return numpy.asscalar(obj)
+            return obj.item()
         elif isinstance(obj, (numpy.ndarray,)):
             return obj.tolist()
         return json.JSONEncoder.default(self, obj)


### PR DESCRIPTION
`python3.8/site-packages/mpld3/_display.py:138: DeprecationWarning: np.asscalar(a) is deprecated since NumPy v1.16, use a.item() instead`