### PR TITLE
Tests: Allow old and new dasharray values

### DIFF
--- a/mpld3/tests/test_elements.py
+++ b/mpld3/tests/test_elements.py
@@ -22,7 +22,7 @@ def test_line():
     assert_equal(line['alpha'], 0.3)
     assert_equal(line['color'], "#000000")
     assert_equal(line['coordinates'], 'data')
-    assert_equal(line['dasharray'], '7.4,3.2')
+    assert line['dasharray'] in  ['7.4,3.2', '6,6']
     assert_equal(line['zorder'], 10)
     assert_equal(line['linewidth'], 2)
 


### PR DESCRIPTION
With matplotlib 3.6.2 we now get the old value of '6,6' in this test:


```
[    9s] =================================== FAILURES ===================================
[    9s] __________________________________ test_line ___________________________________
[    9s] 
[    9s]     def test_line():
[    9s]         fig, ax = plt.subplots()
[    9s]         ax.plot(np.arange(10), np.random.random(10),
[    9s]                 '--k', alpha=0.3, zorder=10, lw=2)
[    9s]         rep = fig_to_dict(fig)
[    9s]         axrep = rep['axes'][0]
[    9s]         line = axrep['lines'][0]
[    9s]     
[    9s]         assert_equal(list(sorted(line.keys())),
[    9s]                      ['alpha', 'color', 'coordinates', 'dasharray', 'data',
[    9s]                       'drawstyle', 'id', 'linewidth', 'xindex', 'yindex',
[    9s]                       'zorder'])
[    9s]         assert_equal(line['alpha'], 0.3)
[    9s]         assert_equal(line['color'], "#000000")
[    9s]         assert_equal(line['coordinates'], 'data')
[    9s] >       assert_equal(line['dasharray'], '7.4,3.2')
[    9s] E       AssertionError: 
[    9s] E       Items are not equal:
[    9s] E        ACTUAL: '6,6'
[    9s] E        DESIRED: '7.4,3.2'
[    9s] 
[    9s] mpld3/tests/test_elements.py:25: AssertionError
[    9s] =============================== warnings summary ===============================
```

This reverts part of a2fef11d821f3c2077975a09ca290f5a840d6c3c