### PR TITLE
Avoid MPL API removals

### DIFF
--- a/mpld3/test_plots/test_patches.py
+++ b/mpld3/test_plots/test_patches.py
@@ -15,14 +15,14 @@ def create_plot():
 
     p = [patches.Arrow(0.75, 0.75, 0.5, 0.5),
          patches.Circle((1, 2), 0.4),
-         patches.RegularPolygon((1, 3), 5, 0.4),
+         patches.RegularPolygon((1, 3), 5, radius=0.4),
          patches.Rectangle((1.6, 0.75), 0.8, 0.5),
          patches.CirclePolygon((2, 2), 0.4),
          patches.Polygon([[1.75, 3], [2, 3.25], [2.25, 3],
                           [2, 2.75], [1.75, 3]]),
          patches.Wedge((3, 1), 0.4, 0, 270),
          patches.Ellipse((3, 2), 0.6, 0.4),
-         patches.Arc((3, 3), 0.5, 0.5, 270, 90)]
+         patches.Arc((3, 3), 0.5, 0.5, angle=270, theta1=90)]
 
     for patch in p:
         patch.set_facecolor(rcolor_1)


### PR DESCRIPTION
Positional arguments are no longer valid for Artists: https://matplotlib.org/stable/api/prev_api_changes/api_changes_3.8.0.html#positional-keyword-arguments

Fixes 

```
[   25s] _________________________________ test_patches _________________________________
[   25s] 
[   25s]     def test_patches():
[   25s] >       fig = create_plot()
[   25s] 
[   25s] mpld3/test_plots/test_patches.py:56: 
[   25s] _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
[   25s] 
[   25s]     def create_plot():
[   25s]         fig, ax = plt.subplots()
[   25s]         ax.grid(color='lightgray')
[   25s]     
[   25s]         rcolor_1 = [0.7074445660822728, 0.10479000173471098, 0.6414668195780913]
[   25s]     
[   25s]         rcolor_2 = [0.22633933378197624, 0.7236195586385642, 0.5361006106618125]
[   25s]     
[   25s]         p = [patches.Arrow(0.75, 0.75, 0.5, 0.5),
[   25s]              patches.Circle((1, 2), 0.4),
[   25s] >            patches.RegularPolygon((1, 3), 5, 0.4),
[   25s]              patches.Rectangle((1.6, 0.75), 0.8, 0.5),
[   25s]              patches.CirclePolygon((2, 2), 0.4),
[   25s]              patches.Polygon([[1.75, 3], [2, 3.25], [2.25, 3],
[   25s]                               [2, 2.75], [1.75, 3]]),
[   25s]              patches.Wedge((3, 1), 0.4, 0, 270),
[   25s]              patches.Ellipse((3, 2), 0.6, 0.4),
[   25s]              patches.Arc((3, 3), 0.5, 0.5, 270, 90)]
[   25s] E       TypeError: __init__() takes 3 positional arguments but 4 were given
[   25s] 
[   25s] mpld3/test_plots/test_patches.py:18: TypeError
[   25s] =============================== warnings summary ===============================

and


[    9s] >            patches.Arc((3, 3), 0.5, 0.5, 270, 90)]
[    9s] E       TypeError: __init__() takes 4 positional arguments but 6 were given
[    9s] 
[    9s] mpld3/test_plots/test_patches.py:25: TypeError

```