### PR TITLE
Use raw strings in re functions

### DIFF
--- a/doc/sphinxext/numpy_ext/docscrape.py
+++ b/doc/sphinxext/numpy_ext/docscrape.py
@@ -266,7 +266,7 @@ class NumpyDocString(object):
 
         summary = self._doc.read_to_next_empty_line()
         summary_str = " ".join([s.strip() for s in summary]).strip()
-        if re.compile('^([\w., ]+=)?\s*[\w\.]+\(.*\)$').match(summary_str):
+        if re.compile(r'^([\w., ]+=)?\s*[\w\.]+\(.*\)$').match(summary_str):
             self['Signature'] = summary_str
             if not self._is_at_section():
                 self['Summary'] = self._doc.read_to_next_empty_line()

--- a/mpld3/_display.py
+++ b/mpld3/_display.py
@@ -243,7 +243,7 @@ def fig_to_html(fig, d3_url=None, mpld3_url=None, no_extras=False,
 
     if figid is None:
         figid = 'fig_' + get_id(fig) + str(int(random.random() * 1E10))
-    elif re.search('\s', figid):
+    elif re.search(r'\s', figid):
         raise ValueError("figid must not contain spaces")
 
     renderer = MPLD3Renderer()

--- a/mpld3/utils.py
+++ b/mpld3/utils.py
@@ -26,9 +26,9 @@ def html_id_ok(objid, html5=False):
     If html5 == True, then use the more liberal html5 rules.
     """
     if html5:
-        return not re.search('\s', objid)
+        return not re.search(r'\s', objid)
     else:
-        return bool(re.match("^[a-zA-Z][a-zA-Z0-9\-\.\:\_]*$", objid))
+        return bool(re.match(r"^[a-zA-Z][a-zA-Z0-9\-\.\:\_]*$", objid))
 
 
 def get_id(obj, suffix="", prefix="el", warn_on_invalid=True):


### PR DESCRIPTION
## Problem
There are warnings about ""invalid escape sequence '\s'" in:

* mpld3/utils.py:29
* mpld3/utils.py:31
* mpld3/_display.py:246

## Solution

Change strings used in calls of re functions to raw strings